### PR TITLE
fix: use interface over type

### DIFF
--- a/index.json
+++ b/index.json
@@ -56,7 +56,7 @@
         "@typescript-eslint/no-extra-non-null-assertion": "error",
         "@typescript-eslint/no-import-type-side-effects": "error",
         "@typescript-eslint/consistent-indexed-object-style": ["error", "record"],
-        "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+        "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
         "@typescript-eslint/consistent-type-imports": [
             "error",
             {


### PR DESCRIPTION
Most of the cases declaring object types using interface is prefered by the community.

REF: https://www.totaltypescript.com/type-vs-interface-which-should-you-use
INTERNAL REF: https://discord.com/channels/1169689282378739763/1171856741147869356/1187278003588304947